### PR TITLE
fix: re-include PocketCsvParser.Ndjson into the code coverage

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,6 +55,8 @@ test_script:
     $ErrorActionPreference = "Stop"
     dotnet test PocketCsvReader.Testing -c Release /p:CollectCoverage=true /p:Include="[PocketCsvReader]*" /p:CoverletOutputFormat=opencover /p:Threshold=10 /p:ThresholdType=line /p:CoverletOutput=../.coverage/coverage.PocketCsvReader.xml --test-adapter-path:. --logger:Appveyor --no-build --nologo
     $globalTestResult = $LastExitCode
+    dotnet test PocketCsvReader.Ndjson.Testing -c Release /p:CollectCoverage=true /p:Include="[PocketCsvReader*]*" /p:CoverletOutputFormat=opencover /p:Threshold=10 /p:ThresholdType=line /p:CoverletOutput=../.coverage/coverage.PocketCsvReader.Ndjson.xml --test-adapter-path:. --logger:Appveyor --no-build --nologo
+    $globalTestResult += $LastExitCode
     if($globalTestResult -ne 0) { $host.SetShouldExit($globalTestResult) }
 
 - pwsh: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated test automation to include additional test coverage for the Ndjson testing project, ensuring both test suites are executed and their results are aggregated during the build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->