### PR TITLE
feat: BatchCsvReader accepts functions returning streams

### DIFF
--- a/PocketCsvReader/CsvBatchDataReader.cs
+++ b/PocketCsvReader/CsvBatchDataReader.cs
@@ -5,7 +5,7 @@ using System.Data;
 namespace PocketCsvReader;
 public class CsvBatchDataReader : IDataReader
 {
-    private bool _allStreamsOpen = false;
+    private readonly bool _allStreamsOpen = false;
     private IEnumerator<Func<Stream>> Streams { get; }
     private Stream? _currentStream;
     private CsvProfile Profile { get; }
@@ -105,8 +105,8 @@ public class CsvBatchDataReader : IDataReader
         if (!_isClosed)
         {
             _isClosed = true;
-            Current?.Dispose();
             _currentStream?.Dispose();
+            Current?.Dispose();
             if (_allStreamsOpen)
             {
                 while (Streams.MoveNext())

--- a/PocketCsvReader/CsvBatchDataReader.cs
+++ b/PocketCsvReader/CsvBatchDataReader.cs
@@ -5,7 +5,9 @@ using System.Data;
 namespace PocketCsvReader;
 public class CsvBatchDataReader : IDataReader
 {
-    private IEnumerator<Stream> Streams { get; }
+    private bool _allStreamsOpen = false;
+    private IEnumerator<Func<Stream>> Streams { get; }
+    private Stream? _currentStream;
     private CsvProfile Profile { get; }
 
     private CsvDataReader? Current { get; set; }
@@ -13,6 +15,12 @@ public class CsvBatchDataReader : IDataReader
     private int fileCount = 0;
 
     public CsvBatchDataReader(IEnumerable<Stream> streams, CsvProfile profile)
+        : this(streams.Select<Stream, Func<Stream>>(x => () => x), profile)
+    {
+        _allStreamsOpen = true;
+    }
+
+    public CsvBatchDataReader(IEnumerable<Func<Stream>> streams, CsvProfile profile)
     {
         (Streams, Profile) = (streams.GetEnumerator(), profile);
         MoveNext();
@@ -24,8 +32,18 @@ public class CsvBatchDataReader : IDataReader
         var fields = Current?.Fields;
 
         Current?.Dispose();
+        _currentStream?.Dispose();
 
-        Current = Streams.MoveNext() ? new CsvDataReader(Streams.Current, Profile) : null;
+        if (Streams.MoveNext())
+        {
+            _currentStream = Streams.Current.Invoke();
+            Current = new CsvDataReader(_currentStream, Profile);
+        }
+        else
+        {
+            Current = null;
+            _currentStream?.Close();
+        }
 
         if (Current is not null && fields is not null && Profile.Dialect.Header && !Profile.Dialect.HeaderRepeat)
             Current!.SetHeaders(fields);
@@ -88,8 +106,12 @@ public class CsvBatchDataReader : IDataReader
         {
             _isClosed = true;
             Current?.Dispose();
-            while (Streams.MoveNext())
-                Streams.Current?.Dispose();
+            _currentStream?.Dispose();
+            if (_allStreamsOpen)
+            {
+                while (Streams.MoveNext())
+                    Streams.Current.Invoke().Dispose();
+            }
             (Streams as IDisposable)?.Dispose();
         }
     }

--- a/PocketCsvReader/CsvReader.cs
+++ b/PocketCsvReader/CsvReader.cs
@@ -208,10 +208,11 @@ namespace PocketCsvReader
         }
 
         /// <summary>
-        /// Reads CSV data from a set of streams and provides an <see cref="IDataReader"/> for record-by-record access.
+        /// Reads CSV data from a set of stream openers (lazy - evaluated) and provides an
+        /// <see cref="IDataReader"/> for record-by-record access.
         /// </summary>
-        /// <param name="streams">
-        /// The enumerable of <see cref="stream"/> containing the CSV data. The streams must be readable and positioned
+        /// <param name="openers">
+        /// Functions returning a <see cref="Stream"/> positioned at the start of the CSV content. Streams are opened lazily
         /// at the start of the content.
         /// </param>
         /// <returns>

--- a/PocketCsvReader/CsvReader.cs
+++ b/PocketCsvReader/CsvReader.cs
@@ -208,6 +208,31 @@ namespace PocketCsvReader
         }
 
         /// <summary>
+        /// Reads CSV data from a set of streams and provides an <see cref="IDataReader"/> for record-by-record access.
+        /// </summary>
+        /// <param name="streams">
+        /// The enumerable of <see cref="stream"/> containing the CSV data. The streams must be readable and positioned
+        /// at the start of the content.
+        /// </param>
+        /// <returns>
+        /// An <see cref="CsvBatchDataReader"/> instance for sequential, read-only access to the CSV records and fields.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">Thrown if the streams contain no element.</exception>
+        /// <remarks>
+        /// This method does not manage the lifecycle of the stream; the caller is responsible for closing it.
+        /// </remarks>
+        public CsvBatchDataReader ToDataReader(IEnumerable<Func<Stream>> openers)
+        {
+            if (openers == null)
+                throw new ArgumentNullException(nameof(openers), "Stream openers collection cannot be null.");
+
+            if (!openers.Any())
+                throw new ArgumentException("Stream openers collection cannot be empty.", nameof(openers));
+
+            return new CsvBatchDataReader(openers, Profile);
+        }
+
+        /// <summary>
         /// Reads a CSV file and returns an enumerable of arrays representing records as fields.
         /// </summary>
         /// <param name="filename">The full path of the CSV file to read.</param>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for creating batch data readers from collections of stream-opening functions, enabling deferred (lazy) stream initialization.
  - Introduced a new method for generating data readers from stream-opening functions.

- **Bug Fixes**
  - Ensured proper disposal of streams when using deferred stream opening.

- **Tests**
  - Added tests to verify correct behavior and disposal of streams when initialized via stream-opening functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->