### PR TITLE
chore: bump Microsoft.NET.Test.Sdk from 17.14.0 to 17.14.1

### DIFF
--- a/PocketCsvReader.Ndjson.Testing/PocketCsvReader.Ndjson.Testing.csproj
+++ b/PocketCsvReader.Ndjson.Testing/PocketCsvReader.Ndjson.Testing.csproj
@@ -9,7 +9,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />

--- a/PocketCsvReader.Testing/PocketCsvReader.Testing.csproj
+++ b/PocketCsvReader.Testing/PocketCsvReader.Testing.csproj
@@ -36,7 +36,7 @@
   <ItemGroup>
     <PackageReference Include="Chrononuensis" Version="0.23.9" />
     <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.4.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="NUnit" Version="4.3.2" />
     <!--<PackageReference Include="NUnit.Analyzers" Version="3.10.0" />-->
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated test framework dependencies to the latest version for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->